### PR TITLE
Fix logging error properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ module.exports = ({ logger = console, level = 'error' } = {}) => {
             // if there are a `statusCode` and an `error` field
             // this is a valid http error object
             if (typeof logger[level] === 'function') {
-                logger[level](error);
+                logger[level]({
+                    error: R.pick(['name', 'message', 'stack', 'details', 'status', 'statusCode', 'expose'], error),
+                });
             }
 
             // eslint-disable-next-line no-param-reassign

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibsted/middy-error-handler",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibsted/middy-error-handler",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Middy middleware for adding caching headers to success response and errors",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Otherwise error gets converted to a string somewhere and loses most of its data e.g. `details`.